### PR TITLE
chore(energy-assistant-dev): sync dev snapshot 01bb007

### DIFF
--- a/energy-assistant-dev/CHANGELOG.md
+++ b/energy-assistant-dev/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.0-dev (2026-03-29)
+
+Dev snapshot from `main` (commit [01bb007](https://github.com/CyberDNS/energy-assistant/commit/01bb007a8e08c889383d7302ddf97739d760b937)).
+
+
+
 This add-on tracks the `dev` tag of [ghcr.io/cyberdns/energy-assistant](https://github.com/CyberDNS/energy-assistant).
 For detailed release notes see the [upstream releases](https://github.com/CyberDNS/energy-assistant/releases).
 

--- a/energy-assistant-dev/config.json
+++ b/energy-assistant-dev/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Energy Assistant (dev)",
-  "version": "0.0.1",
+  "version": "0.1.0-dev",
   "slug": "energy-assistant-dev",
   "description": "Open-source, vendor-neutral energy management platform for homeowners (dev channel — nightly builds from main branch)",
   "url": "https://github.com/CyberDNS/energy-assistant",


### PR DESCRIPTION
Automated sync from CyberDNS/energy-assistant commit [01bb007](https://github.com/CyberDNS/energy-assistant/commit/01bb007a8e08c889383d7302ddf97739d760b937) on `main`.

This PR updates `energy-assistant-dev` in the add-on repository.

For a full list of changes see the [commit history](https://github.com/CyberDNS/energy-assistant/commits/main).