### PR TITLE
chore(energy-assistant-dev): sync dev snapshot cd98259

### DIFF
--- a/energy-assistant-dev/CHANGELOG.md
+++ b/energy-assistant-dev/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.0-dev (2026-03-30)
+
+Dev snapshot from `main` (commit [cd98259](https://github.com/CyberDNS/energy-assistant/commit/cd98259afa70a039d6bc2924eaa757ed55e8e380)).
+
+
+
 ## 0.1.0-dev (2026-03-29)
 
 Dev snapshot from `main` (commit [914ecf6](https://github.com/CyberDNS/energy-assistant/commit/914ecf65224221e625f3707b7bd1331bf06e5e21)).


### PR DESCRIPTION
Automated sync from CyberDNS/energy-assistant commit [cd98259](https://github.com/CyberDNS/energy-assistant/commit/cd98259afa70a039d6bc2924eaa757ed55e8e380) on `main`.

This PR updates `energy-assistant-dev` in the add-on repository.

For a full list of changes see the [commit history](https://github.com/CyberDNS/energy-assistant/commits/main).