### PR TITLE
chore(energy-assistant-dev): sync dev snapshot b1172d5

### DIFF
--- a/energy-assistant-dev/CHANGELOG.md
+++ b/energy-assistant-dev/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 0.1.0-dev (2026-04-18)
 
+Dev snapshot from `main` (commit [b1172d5](https://github.com/CyberDNS/energy-assistant/commit/b1172d57f0b327a2fcfde3e0f7ac001951777b63)).
+
+
+
+## 0.1.0-dev (2026-04-18)
+
 Dev snapshot from `main` (commit [704955e](https://github.com/CyberDNS/energy-assistant/commit/704955ed4e2d6f413d04bf36efd44c18b977e47f)).
 
 


### PR DESCRIPTION
Automated sync from CyberDNS/energy-assistant commit [b1172d5](https://github.com/CyberDNS/energy-assistant/commit/b1172d57f0b327a2fcfde3e0f7ac001951777b63) on `main`.

This PR updates `energy-assistant-dev` in the add-on repository.

For a full list of changes see the [commit history](https://github.com/CyberDNS/energy-assistant/commits/main).