### PR TITLE
chore(energy-assistant-dev): sync dev snapshot b09f5df

### DIFF
--- a/energy-assistant-dev/CHANGELOG.md
+++ b/energy-assistant-dev/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 0.1.0-dev (2026-07-05)
 
+Dev snapshot from `main` (commit [b09f5df](https://github.com/CyberDNS/energy-assistant/commit/b09f5df34c2c447376e65d756a27aa462123edd3)).
+
+
+
+## 0.1.0-dev (2026-07-05)
+
 Dev snapshot from `main` (commit [9f439d3](https://github.com/CyberDNS/energy-assistant/commit/9f439d348c757553b61cbd5d68c999c0b0fcf1a8)).
 
 


### PR DESCRIPTION
Automated sync from CyberDNS/energy-assistant commit [b09f5df](https://github.com/CyberDNS/energy-assistant/commit/b09f5df34c2c447376e65d756a27aa462123edd3) on `main`.

This PR updates `energy-assistant-dev` in the add-on repository.

For a full list of changes see the [commit history](https://github.com/CyberDNS/energy-assistant/commits/main).