### PR TITLE
chore(energy-assistant-dev): sync dev snapshot 3d77d74

### DIFF
--- a/energy-assistant-dev/CHANGELOG.md
+++ b/energy-assistant-dev/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 0.1.0-dev (2026-07-05)
 
+Dev snapshot from `main` (commit [3d77d74](https://github.com/CyberDNS/energy-assistant/commit/3d77d74c35d9ac2edc2b0a5b8e464de9474ea586)).
+
+
+
+## 0.1.0-dev (2026-07-05)
+
 Dev snapshot from `main` (commit [a6755c9](https://github.com/CyberDNS/energy-assistant/commit/a6755c909a1b28dd12d4cc3368f4b2bf7304c92a)).
 
 


### PR DESCRIPTION
Automated sync from CyberDNS/energy-assistant commit [3d77d74](https://github.com/CyberDNS/energy-assistant/commit/3d77d74c35d9ac2edc2b0a5b8e464de9474ea586) on `main`.

This PR updates `energy-assistant-dev` in the add-on repository.

For a full list of changes see the [commit history](https://github.com/CyberDNS/energy-assistant/commits/main).