### PR TITLE
chore(energy-assistant-dev): sync dev snapshot 826eceb

### DIFF
--- a/energy-assistant-dev/CHANGELOG.md
+++ b/energy-assistant-dev/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.0-dev (2026-07-10)
+
+Dev snapshot from `main` (commit [826eceb](https://github.com/CyberDNS/energy-assistant/commit/826eceb813421496fcb5dd4856d21a1748617259)).
+
+
+
 ## 0.1.0-dev (2026-07-05)
 
 Dev snapshot from `main` (commit [0b3d686](https://github.com/CyberDNS/energy-assistant/commit/0b3d686d63481a2c594a5c606315050d99fb6093)).


### PR DESCRIPTION
Automated sync from CyberDNS/energy-assistant commit [826eceb](https://github.com/CyberDNS/energy-assistant/commit/826eceb813421496fcb5dd4856d21a1748617259) on `main`.

This PR updates `energy-assistant-dev` in the add-on repository.

For a full list of changes see the [commit history](https://github.com/CyberDNS/energy-assistant/commits/main).