### PR TITLE
chore(energy-assistant-dev): sync dev snapshot 2ac18b5

### DIFF
--- a/energy-assistant-dev/CHANGELOG.md
+++ b/energy-assistant-dev/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.0-dev (2026-07-12)
+
+Dev snapshot from `main` (commit [2ac18b5](https://github.com/CyberDNS/energy-assistant/commit/2ac18b5b74772636b2c7bfcccd8df57cb3d47485)).
+
+
+
 ## 0.1.0-dev (2026-07-11)
 
 Dev snapshot from `main` (commit [421f702](https://github.com/CyberDNS/energy-assistant/commit/421f702893637e7a76fb1e4df6de98ab1ccce433)).


### PR DESCRIPTION
Automated sync from CyberDNS/energy-assistant commit [2ac18b5](https://github.com/CyberDNS/energy-assistant/commit/2ac18b5b74772636b2c7bfcccd8df57cb3d47485) on `main`.

This PR updates `energy-assistant-dev` in the add-on repository.

For a full list of changes see the [commit history](https://github.com/CyberDNS/energy-assistant/commits/main).