### PR TITLE
chore(energy-assistant-dev): sync dev snapshot 1cbe31e

### DIFF
--- a/energy-assistant-dev/CHANGELOG.md
+++ b/energy-assistant-dev/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 0.1.0-dev (2026-07-12)
 
+Dev snapshot from `main` (commit [1cbe31e](https://github.com/CyberDNS/energy-assistant/commit/1cbe31e2f53149de2c64ce18f9b2d132552c78cd)).
+
+
+
+## 0.1.0-dev (2026-07-12)
+
 Dev snapshot from `main` (commit [2ac18b5](https://github.com/CyberDNS/energy-assistant/commit/2ac18b5b74772636b2c7bfcccd8df57cb3d47485)).
 
 


### PR DESCRIPTION
Automated sync from CyberDNS/energy-assistant commit [1cbe31e](https://github.com/CyberDNS/energy-assistant/commit/1cbe31e2f53149de2c64ce18f9b2d132552c78cd) on `main`.

This PR updates `energy-assistant-dev` in the add-on repository.

For a full list of changes see the [commit history](https://github.com/CyberDNS/energy-assistant/commits/main).