### PR TITLE
chore(energy-assistant-edge): bump to v0.1.1

### DIFF
--- a/energy-assistant-edge/CHANGELOG.md
+++ b/energy-assistant-edge/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.1.1 (2026-08-09)
+
+## What's Changed
+* fix(docker-publish): strip the leading v from the immutable image tag by @CyberDNS in https://github.com/CyberDNS/energy-assistant/pull/32
+
+
+**Full Changelog**: https://github.com/CyberDNS/energy-assistant/compare/v0.1.0...v0.1.1
+
+
+
 ## 0.1.0 (2026-08-09)
 
 ## What's Changed

--- a/energy-assistant-edge/config.yaml
+++ b/energy-assistant-edge/config.yaml
@@ -1,5 +1,5 @@
 name: Energy Assistant (edge)
-version: 0.1.0
+version: 0.1.1
 slug: energy-assistant-edge
 description: Open-source, vendor-neutral energy management platform for homeowners (edge channel — validated pre-release builds)
 url: https://github.com/CyberDNS/energy-assistant


### PR DESCRIPTION
Automated sync from CyberDNS/energy-assistant release [v0.1.1](https://github.com/CyberDNS/energy-assistant/releases/tag/v0.1.1).