### PR TITLE
chore(Lupusec2Mqtt-dev): sync dev snapshot bc98bca

### DIFF
--- a/Lupusec2Mqtt-dev/CHANGELOG.md
+++ b/Lupusec2Mqtt-dev/CHANGELOG.md
@@ -1,3 +1,9 @@
 # Changelog
 
+## 0.0.0-dev.bc98bca (2026-08-09)
+
+Dev snapshot from `master` (commit [bc98bca](https://github.com/CyberDNS/Lupusec2Mqtt/commit/bc98bca43b21f46d71669d4fd0c71088d04e788d)).
+
+
+
 Don't install this version if you don't know what you are doing.

--- a/Lupusec2Mqtt-dev/config.json
+++ b/Lupusec2Mqtt-dev/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Lupusec2Mqtt Development",
-  "version": "4.0.0",
+  "version": "0.0.0-dev.bc98bca",
   "slug": "Lupusec2Mqtt-dev",
   "description": "Connect your Lupusec Alarm system to HomeAssistant by an MQTT integration",
   "startup": "application",


### PR DESCRIPTION
Automated sync from CyberDNS/Lupusec2Mqtt commit [bc98bca](https://github.com/CyberDNS/Lupusec2Mqtt/commit/bc98bca43b21f46d71669d4fd0c71088d04e788d) on `master`.