### PR TITLE
chore(Lupusec2Mqtt-dev): sync dev snapshot a28c64d

### DIFF
--- a/Lupusec2Mqtt-dev/CHANGELOG.md
+++ b/Lupusec2Mqtt-dev/CHANGELOG.md
@@ -1,3 +1,9 @@
 # Changelog
 
+## 0.0.0-dev.a28c64d (2026-08-09)
+
+Dev snapshot from `master` (commit [a28c64d](https://github.com/CyberDNS/Lupusec2Mqtt/commit/a28c64db8ee048d7ceef4c03c45e959d20e8643b)).
+
+
+
 Don't install this version if you don't know what you are doing.

--- a/Lupusec2Mqtt-dev/config.json
+++ b/Lupusec2Mqtt-dev/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Lupusec2Mqtt Development",
-  "version": "4.0.0",
+  "version": "0.0.0-dev.a28c64d",
   "slug": "Lupusec2Mqtt-dev",
   "description": "Connect your Lupusec Alarm system to HomeAssistant by an MQTT integration",
   "startup": "application",


### PR DESCRIPTION
Automated sync from CyberDNS/Lupusec2Mqtt commit [a28c64d](https://github.com/CyberDNS/Lupusec2Mqtt/commit/a28c64db8ee048d7ceef4c03c45e959d20e8643b) on `master`.