### PR TITLE
chore(Lupusec2Mqtt-edge): bump to v4.1.1

### DIFF
--- a/Lupusec2Mqtt-edge/CHANGELOG.md
+++ b/Lupusec2Mqtt-edge/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 4.1.1 (2026-08-09)
+
+## What's Changed
+* fix(lupusec): retry request when token re-authentication itself hits a 401 by @CyberDNS in https://github.com/CyberDNS/Lupusec2Mqtt/pull/106
+
+**Full Changelog**: https://github.com/CyberDNS/Lupusec2Mqtt/compare/v2.0.0...v4.1.1
+
+
+
 ## 4.1.0
 
 - fix: smoke detector state handling fixed

--- a/Lupusec2Mqtt-edge/config.json
+++ b/Lupusec2Mqtt-edge/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Lupusec2Mqtt Edge",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "slug": "Lupusec2Mqtt-edge",
   "description": "Connect your Lupusec Alarm system to HomeAssistant by an MQTT integration",
   "startup": "application",


### PR DESCRIPTION
Automated sync from CyberDNS/Lupusec2Mqtt release [v4.1.1](https://github.com/CyberDNS/Lupusec2Mqtt/releases/tag/v4.1.1).