### PR TITLE
chore(Lupusec2Mqtt-dev): sync dev snapshot 8a1796b

### DIFF
--- a/Lupusec2Mqtt-dev/CHANGELOG.md
+++ b/Lupusec2Mqtt-dev/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.0.0-dev.8a1796b (2026-08-09)
+
+Dev snapshot from `master` (commit [8a1796b](https://github.com/CyberDNS/Lupusec2Mqtt/commit/8a1796b6f4f2004f19f6f767d5e560c0cdbee40a)).
+
+
+
 ## 0.0.0-dev.5ddf6ba (2026-08-09)
 
 Dev snapshot from `master` (commit [5ddf6ba](https://github.com/CyberDNS/Lupusec2Mqtt/commit/5ddf6bae0c2e8637d9aad7f14dcd9067e155ac39)).

--- a/Lupusec2Mqtt-dev/config.json
+++ b/Lupusec2Mqtt-dev/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Lupusec2Mqtt Development",
-  "version": "0.0.0-dev.5ddf6ba",
+  "version": "0.0.0-dev.8a1796b",
   "slug": "Lupusec2Mqtt-dev",
   "description": "Connect your Lupusec Alarm system to HomeAssistant by an MQTT integration",
   "startup": "application",


### PR DESCRIPTION
Automated sync from CyberDNS/Lupusec2Mqtt commit [8a1796b](https://github.com/CyberDNS/Lupusec2Mqtt/commit/8a1796b6f4f2004f19f6f767d5e560c0cdbee40a) on `master`.