### PR TITLE
chore(Lupusec2Mqtt-edge): bump to v4.1.2

### DIFF
--- a/Lupusec2Mqtt-edge/CHANGELOG.md
+++ b/Lupusec2Mqtt-edge/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 4.1.2 (2026-08-09)
+
+## What's Changed
+* Add device wrapping for switches, lights, and switch sensors by @CyberDNS with @Copilot in https://github.com/CyberDNS/Lupusec2Mqtt/pull/101
+_If you are migrating from a previous version, delete the discovery config from MQTT (e.g. using MQTT Explorer or another tool of your choice) and restart the add-on._
+
+**Full Changelog**: https://github.com/CyberDNS/Lupusec2Mqtt/compare/v4.1.1...v4.1.2
+
+
+
 ## 4.1.1 (2026-08-09)
 
 ## What's Changed

--- a/Lupusec2Mqtt-edge/config.json
+++ b/Lupusec2Mqtt-edge/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Lupusec2Mqtt Edge",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "slug": "Lupusec2Mqtt-edge",
   "description": "Connect your Lupusec Alarm system to HomeAssistant by an MQTT integration",
   "startup": "application",


### PR DESCRIPTION
Automated sync from CyberDNS/Lupusec2Mqtt release [v4.1.2](https://github.com/CyberDNS/Lupusec2Mqtt/releases/tag/v4.1.2).